### PR TITLE
Switch it using the puppet_install plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Once you are finished with the instances
 
 Prior to starting, make sure the 'default' security group allows SSH access from your machine.
 
+    $ localhost> vagrant plugin install vagrant-puppet-install
     $ localhost> vagrant plugin install vagrant-aws  
     $ localhost> vagrant box add dummy https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
     $ localhost> git clone https://github.com/continuent/continuent-vagrant.git
@@ -123,3 +124,9 @@ on Centos/Redhat install
 Enusre you local git client in correctly setup not to translate Unix CR and LF characters. If it does it breaks the puppet install.
 
 Replace launch.sh in the setup steps with vagrant up
+
+## Unknown configuration section 'puppet_install'.
+
+Ensure the puppet_install plug in is installed
+
+   $ localhost> vagrant plugin install vagrant-puppet-install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ You can repeat this process with any of the examples subdirectories. View the RE
 
 This process will start a 3-node cluster using 64-bit Virtualbox images.
 
+    $ localhost> vagrant plugin install vagrant-puppet-install
     $ localhost> vagrant box add centos-64-x64 http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.4-x86_64-v20130731.box
     $ localhost> git clone https://github.com/continuent/continuent-vagrant.git
     $ localhost> cd continuent-vagrant
@@ -15,15 +16,15 @@ This process will start a 3-node cluster using 64-bit Virtualbox images.
     $ localhost> cp ~/continuent-tungsten-2.0.4-589.noarch.rpm ./downloads/continuent-tungsten-latest.noarch.rpm
     $ localhost> cp examples/Vagrantfile.3.vbox ./Vagrantfile
     $ localhost> cp examples/STD/default.pp ./manifests/
-    
+
 The launch.sh script will start the images and install the software.
-    
+
     $ localhost> ./launch.sh
 
 Once you are finished with the instances
 
     $ localhost> vagrant destroy -f
-    
+
 ## Using EC2
 
 Prior to starting, make sure the 'default' security group allows SSH access from your machine.
@@ -36,7 +37,7 @@ Prior to starting, make sure the 'default' security group allows SSH access from
     $ localhost> cp ~/continuent-tungsten-2.0.4-589.noarch.rpm ./downloads/continuent-tungsten-latest.noarch.rpm
     $ localhost> cp examples/Vagrantfile.3.ec2 ./Vagrantfile
     $ localhost> cp examples/STD/default.pp ./manifests/
-    
+
 The launch.sh script will start the images and install the software. Update the files at the top of Vagrantfile to match your environment. Modify the GROUP value if you are working with multiple continuent-vagrant directories.
 
     $ localhost> ./launch.sh
@@ -52,11 +53,11 @@ The continuent/tungsten module includes a very basic MySQL installation. If you 
 Download the mysql module into your Vagrant directory
 
     $> git clone https://github.com/puppetlabs/puppetlabs-mysql.git modules/mysql
-    
+
 Update the Class["continuent_vagrant"] declaration and remove the installMySQL setting from the Class["tungsten"] declaration.
 
     class { "continuent_vagrant" : clusterData => $clusterData, installPuppetLabsMySQL => true}
-    
+
 The result will be something like this if we are using the MasterSlave example.
 
     $clusterData = {
@@ -66,7 +67,7 @@ The result will be something like this if we are using the MasterSlave example.
     		"slaves" => "db2,db3",
     	},
     }
-    
+
     class { "continuent_vagrant" : clusterData => $clusterData, installPuppetLabsMySQL => true}
 
     class { 'tungsten' :
@@ -75,21 +76,21 @@ The result will be something like this if we are using the MasterSlave example.
     	installReplicatorSoftware => true,
     	clusterData => $clusterData,
     }
-    
+
 # Using the vagrant-cachier plugin
 
 The vagrant-cachier plugin can keep packages on your machine so they don't need to be downloaded multiple times.
 
     $ localhost > vagrant plugin install vagrant-cachier
-    
+
 Add this to your Vagrantfile after the 'config.vm.network' line.
 
     if Vagrant.has_plugin?("vagrant-cachier")
-      # Configure cached packages to be shared between instances 
+      # Configure cached packages to be shared between instances
       # of the same base box.
       config.cache.scope = :box
     end
-    
+
 You may get errors the first time you run the `./launch.sh` script. Try starting up your servers with `vagrant up` the first time. The `./launch.sh` script should run properly after that.
 
 # Automatic AWS instance shutdown

--- a/examples/Vagrantfile.2.ec2
+++ b/examples/Vagrantfile.2.ec2
@@ -16,13 +16,14 @@ Vagrant.configure("2") do |vcfg|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
 			config.vm.box = "dummy"
-			config.ssh.pty = true 
-		
+			config.ssh.pty = true
+
 			config.vm.provider :aws do |aws, override|
 				aws.instance_type = "m3.large"
-				
+				config.puppet_install.puppet_version = :latest
+
 				if i <= 3
-					# Amazon Linux AMI in us-east-1	
+					# Amazon Linux AMI in us-east-1
 					aws.ami = "ami-83e4bcea"
 					aws.region = "us-east-1"
 				elsif i <= 6
@@ -30,27 +31,27 @@ Vagrant.configure("2") do |vcfg|
 					aws.ami = "ami-ccf297fc"
 					aws.region = "us-west-2"
 				elsif i <= 9
-					# Amazon Linux AMI in us-west-1	
+					# Amazon Linux AMI in us-west-1
 					aws.ami = "ami-5256b825"
 					aws.region = "eu-west-1"
 				end
-				
+
 				aws.access_key_id = ACCESS_KEY
 				aws.secret_access_key = SECRET_ACCESS_KEY
 				aws.keypair_name = SSH_KEYPAIR
-				
+
 				aws.tags = {
 					Name: "#{name.to_s()}.#{GROUP}",
 					VagrantGroup: GROUP,
 					Vagrant: 1,
 					CreatedAt: Time.now.strftime('%Y-%m-%dT%l:%M:%S')
 				}
-				
+
 				# Set this value to a positive integer to force the EC2 hosts to automatically
 				# shutdown. The value is the number of minutes before shutdown begins.
 				#SHUTDOWN_TIMER = nil
-				
-				# Write a command to automatically shutdown the instance 
+
+				# Write a command to automatically shutdown the instance
 				# after a set number of minutes
 				unless defined?(SHUTDOWN_TIMER)
 					SHUTDOWN_TIMER = nil
@@ -60,13 +61,11 @@ Vagrant.configure("2") do |vcfg|
 				else
 					timer = ""
 				end
-				
+
 				# Disable the requiretty setting and install puppet
 				aws.user_data = "#!/bin/bash
 				hostname #{name.to_s()}
 				echo -e '[main] \nenabled=0' > /etc/yum/pluginconf.d/priorities.conf
-				rpm --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-                rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 				perl -pi -e 's/^Defaults[ ]*requiretty/#Defaults requiretty/' /etc/sudoers
 				yum install -y ruby18 rubygems18 rubygem18-aws-sdk ruby18-devel\nalternatives --set ruby /usr/bin/ruby1.8
 				yum install -y puppet#{timer}"
@@ -78,10 +77,10 @@ Vagrant.configure("2") do |vcfg|
 						'Ebs.DeleteOnTermination' => true
 					}
 				]
-		
+
 				override.ssh.username = "ec2-user"
 				override.ssh.private_key_path = SSH_PRIVATE_KEY
-				
+
 				config.vm.provision "puppet" do |puppet|
 					puppet.options = ""
 					puppet.module_path = "modules"

--- a/examples/Vagrantfile.2.vbox
+++ b/examples/Vagrantfile.2.vbox
@@ -2,8 +2,9 @@ Vagrant.configure("2") do |vcfg|
 	(1..2).each{|i|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
+		  config.puppet_install.puppet_version = :latest
 			config.vm.box = "centos-64-x64"
-			
+
 			config.vm.provider :virtualbox do |vb|
 				# Update this line to increase the amount of available memory
 				vb.customize ["modifyvm", :id, "--memory", "1024"]
@@ -19,7 +20,7 @@ Vagrant.configure("2") do |vcfg|
 					"vagrant" => "1",
 					"fqdn" => "db#{i}"
 				}
-				
+
 				# Set the temp directory name for an error in Vagrant 1.4.1
 				begin
 					puppet.temp_dir = "/tmp/vagrant-puppet"

--- a/examples/Vagrantfile.3.ec2
+++ b/examples/Vagrantfile.3.ec2
@@ -16,13 +16,14 @@ Vagrant.configure("2") do |vcfg|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
 			config.vm.box = "dummy"
-			config.ssh.pty = true 
-		
+			config.ssh.pty = true
+
 			config.vm.provider :aws do |aws, override|
 				aws.instance_type = "m3.large"
-				
+				config.puppet_install.puppet_version = :latest
+
 				if i <= 3
-					# Amazon Linux AMI in us-east-1	
+					# Amazon Linux AMI in us-east-1
 					aws.ami = "ami-83e4bcea"
 					aws.region = "us-east-1"
 				elsif i <= 6
@@ -30,27 +31,27 @@ Vagrant.configure("2") do |vcfg|
 					aws.ami = "ami-ccf297fc"
 					aws.region = "us-west-2"
 				elsif i <= 9
-					# Amazon Linux AMI in us-west-1	
+					# Amazon Linux AMI in us-west-1
 					aws.ami = "ami-5256b825"
 					aws.region = "eu-west-1"
 				end
-				
+
 				aws.access_key_id = ACCESS_KEY
 				aws.secret_access_key = SECRET_ACCESS_KEY
 				aws.keypair_name = SSH_KEYPAIR
-				
+
 				aws.tags = {
 					Name: "#{name.to_s()}.#{GROUP}",
 					VagrantGroup: GROUP,
 					Vagrant: 1,
 					CreatedAt: Time.now.strftime('%Y-%m-%dT%l:%M:%S')
 				}
-				
+
 				# Set this value to a positive integer to force the EC2 hosts to automatically
 				# shutdown. The value is the number of minutes before shutdown begins.
 				#SHUTDOWN_TIMER = nil
-				
-				# Write a command to automatically shutdown the instance 
+
+				# Write a command to automatically shutdown the instance
 				# after a set number of minutes
 				unless defined?(SHUTDOWN_TIMER)
 					SHUTDOWN_TIMER = nil
@@ -60,16 +61,14 @@ Vagrant.configure("2") do |vcfg|
 				else
 					timer = ""
 				end
-				
+
 				# Disable the requiretty setting and install puppet
 				aws.user_data = "#!/bin/bash
                                 				hostname #{name.to_s()}
-                                				echo -e '[main] \nenabled=0' > /etc/yum/pluginconf.d/priorities.conf
-                                				rpm --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-                                                rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+																				echo -e '[main] \nenabled=0' > /etc/yum/pluginconf.d/priorities.conf
                                 				perl -pi -e 's/^Defaults[ ]*requiretty/#Defaults requiretty/' /etc/sudoers
                                 				yum install -y ruby18 rubygems18 rubygem18-aws-sdk ruby18-devel\nalternatives --set ruby /usr/bin/ruby1.8
-                                				yum install -y puppet#{timer}"
+                                				#{timer}"
 
 				aws.block_device_mapping = [
 					{
@@ -78,10 +77,10 @@ Vagrant.configure("2") do |vcfg|
 						'Ebs.DeleteOnTermination' => true
 					}
 				]
-		
+
 				override.ssh.username = "ec2-user"
 				override.ssh.private_key_path = SSH_PRIVATE_KEY
-				
+
 				config.vm.provision "puppet" do |puppet|
 					puppet.options = ""
 					puppet.module_path = "modules"

--- a/examples/Vagrantfile.3.vbox
+++ b/examples/Vagrantfile.3.vbox
@@ -2,8 +2,9 @@ Vagrant.configure("2") do |vcfg|
 	(1..3).each{|i|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
+			config.puppet_install.puppet_version = :latest
 			config.vm.box = "centos-64-x64"
-			
+
 			config.vm.provider :virtualbox do |vb|
 				# Update this line to increase the amount of available memory
 				vb.customize ["modifyvm", :id, "--memory", "1024"]
@@ -19,7 +20,7 @@ Vagrant.configure("2") do |vcfg|
 					"vagrant" => "1",
 					"fqdn" => "db#{i}"
 				}
-				
+
 				# Set the temp directory name for an error in Vagrant 1.4.1
 				begin
 					puppet.temp_dir = "/tmp/vagrant-puppet"

--- a/examples/Vagrantfile.6.ec2
+++ b/examples/Vagrantfile.6.ec2
@@ -16,13 +16,14 @@ Vagrant.configure("2") do |vcfg|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
 			config.vm.box = "dummy"
-			config.ssh.pty = true 
-		
+			config.ssh.pty = true
+
 			config.vm.provider :aws do |aws, override|
 				aws.instance_type = "m3.large"
-				
+				config.puppet_install.puppet_version = :latest
+
 				if i <= 3
-					# Amazon Linux AMI in us-east-1	
+					# Amazon Linux AMI in us-east-1
 					aws.ami = "ami-83e4bcea"
 					aws.region = "us-east-1"
 				elsif i <= 6
@@ -30,27 +31,27 @@ Vagrant.configure("2") do |vcfg|
 					aws.ami = "ami-ccf297fc"
 					aws.region = "us-west-2"
 				elsif i <= 9
-					# Amazon Linux AMI in us-west-1	
+					# Amazon Linux AMI in us-west-1
 					aws.ami = "ami-5256b825"
 					aws.region = "eu-west-1"
 				end
-				
+
 				aws.access_key_id = ACCESS_KEY
 				aws.secret_access_key = SECRET_ACCESS_KEY
 				aws.keypair_name = SSH_KEYPAIR
-				
+
 				aws.tags = {
 					Name: "#{name.to_s()}.#{GROUP}",
 					VagrantGroup: GROUP,
 					Vagrant: 1,
 					CreatedAt: Time.now.strftime('%Y-%m-%dT%l:%M:%S')
 				}
-				
+
 				# Set this value to a positive integer to force the EC2 hosts to automatically
 				# shutdown. The value is the number of minutes before shutdown begins.
 				#SHUTDOWN_TIMER = nil
-				
-				# Write a command to automatically shutdown the instance 
+
+				# Write a command to automatically shutdown the instance
 				# after a set number of minutes
 				unless defined?(SHUTDOWN_TIMER)
 					SHUTDOWN_TIMER = nil
@@ -60,13 +61,11 @@ Vagrant.configure("2") do |vcfg|
 				else
 					timer = ""
 				end
-				
+
 				# Disable the requiretty setting and install puppet
 				aws.user_data = "#!/bin/bash
                 				hostname #{name.to_s()}
                 				echo -e '[main] \nenabled=0' > /etc/yum/pluginconf.d/priorities.conf
-                				rpm --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-                                rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
                 				perl -pi -e 's/^Defaults[ ]*requiretty/#Defaults requiretty/' /etc/sudoers
                 				yum install -y ruby18 rubygems18 rubygem18-aws-sdk ruby18-devel\nalternatives --set ruby /usr/bin/ruby1.8
                 				yum install -y puppet#{timer}"
@@ -78,10 +77,10 @@ Vagrant.configure("2") do |vcfg|
 						'Ebs.DeleteOnTermination' => true
 					}
 				]
-		
+
 				override.ssh.username = "ec2-user"
 				override.ssh.private_key_path = SSH_PRIVATE_KEY
-				
+
 				config.vm.provision "puppet" do |puppet|
 					puppet.options = ""
 					puppet.module_path = "modules"

--- a/examples/Vagrantfile.6.ec2.multiaz
+++ b/examples/Vagrantfile.6.ec2.multiaz
@@ -16,11 +16,12 @@ Vagrant.configure("2") do |vcfg|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
 			config.vm.box = "dummy"
-			config.ssh.pty = true 
-		
+			config.ssh.pty = true
+
 			config.vm.provider :aws do |aws, override|
 				aws.instance_type = "m3.large"
-				
+				config.puppet_install.puppet_version = :latest
+
 				if i <= 2
 					# Amazon Linux AMI in us-east-1
 					aws.ami = "ami-83e4bcea"
@@ -52,23 +53,23 @@ Vagrant.configure("2") do |vcfg|
 					aws.region = "eu-west-1"
 					aws.availability_zone = "eu-west-1b"
 				end
-	
+
 				aws.access_key_id = ACCESS_KEY
 				aws.secret_access_key = SECRET_ACCESS_KEY
 				aws.keypair_name = SSH_KEYPAIR
-				
+
 				aws.tags = {
 					Name: "#{name.to_s()}.#{GROUP}",
 					VagrantGroup: GROUP,
 					Vagrant: 1,
 					CreatedAt: Time.now.strftime('%Y-%m-%dT%l:%M:%S')
 				}
-				
+
 				# Set this value to a positive integer to force the EC2 hosts to automatically
 				# shutdown. The value is the number of minutes before shutdown begins.
 				#SHUTDOWN_TIMER = nil
-				
-				# Write a command to automatically shutdown the instance 
+
+				# Write a command to automatically shutdown the instance
 				# after a set number of minutes
 				unless defined?(SHUTDOWN_TIMER)
 					SHUTDOWN_TIMER = nil
@@ -78,13 +79,11 @@ Vagrant.configure("2") do |vcfg|
 				else
 					timer = ""
 				end
-				
+
 				# Disable the requiretty setting and install puppet
 				aws.user_data = "#!/bin/bash
                 				hostname #{name.to_s()}
                 				echo -e '[main] \nenabled=0' > /etc/yum/pluginconf.d/priorities.conf
-                				rpm --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
-                                rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
                 				perl -pi -e 's/^Defaults[ ]*requiretty/#Defaults requiretty/' /etc/sudoers
                 				yum install -y ruby18 rubygems18 rubygem18-aws-sdk ruby18-devel\nalternatives --set ruby /usr/bin/ruby1.8
                 				yum install -y puppet#{timer}"
@@ -96,10 +95,10 @@ Vagrant.configure("2") do |vcfg|
 						'Ebs.DeleteOnTermination' => true
 					}
 				]
-		
+
 				override.ssh.username = "ec2-user"
 				override.ssh.private_key_path = SSH_PRIVATE_KEY
-				
+
 				config.vm.provision "puppet" do |puppet|
 					puppet.options = ""
 					puppet.module_path = "modules"

--- a/examples/Vagrantfile.6.vbox
+++ b/examples/Vagrantfile.6.vbox
@@ -2,8 +2,9 @@ Vagrant.configure("2") do |vcfg|
 	(1..6).each{|i|
 		name = "db#{i}".to_sym()
 		vcfg.vm.define name do |config|
+			config.puppet_install.puppet_version = :latest
 			config.vm.box = "centos-64-x64"
-			
+
 			config.vm.provider :virtualbox do |vb|
 				# Update this line to increase the amount of available memory
 				vb.customize ["modifyvm", :id, "--memory", "1024"]
@@ -19,7 +20,7 @@ Vagrant.configure("2") do |vcfg|
 					"vagrant" => "1",
 					"fqdn" => "db#{i}"
 				}
-				
+
 				# Set the temp directory name for an error in Vagrant 1.4.1
 				begin
 					puppet.temp_dir = "/tmp/vagrant-puppet"


### PR DESCRIPTION
Remove custom puppet install for EC2 instances
Standardise all Vagrantfiles to use puppet_install plugin to pull the latest version

