### PR TITLE
support for vcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,36 +47,31 @@ Once you are finished with the instances
 
     $ localhost> vagrant destroy -f
 
-# Using puppetlabs/mysql for MySQL installation
 
-The continuent/tungsten module includes a very basic MySQL installation. If you would like to use the more advanced version, you may include the continuent\_vagrant::puppetlabs\_mysql class.
+## Using VMware vCenter
 
-Download the mysql module into your Vagrant directory
+    This process will start a 3-node cluster using 64-bit vCenter images.
 
-    $> git clone https://github.com/puppetlabs/puppetlabs-mysql.git modules/mysql
+        $ localhost> vagrant plugin install vagrant-puppet-install
+        $ localhost> vagrant plugin install vagrant-vcenter
+        $ localhost> git clone https://github.com/continuent/continuent-vagrant.git
+        $ localhost> cd continuent-vagrant
+        $ localhost> git submodule update --init
+        $ localhost> cp ~/continuent-tungsten-2.0.4-589.noarch.rpm ./downloads/continuent-tungsten-latest.noarch.rpm
+        $ localhost> cp examples/Vagrantfile.3.vcenter ./Vagrantfile
+        $ localhost> cp examples/STD/default.pp ./manifests/
 
-Update the Class["continuent_vagrant"] declaration and remove the installMySQL setting from the Class["tungsten"] declaration.
+    Customize the variables in the Vagrantfile to match your vCenter environment
 
-    class { "continuent_vagrant" : clusterData => $clusterData, installPuppetLabsMySQL => true}
+    The launch.sh script will start the images and install the software.
 
-The result will be something like this if we are using the MasterSlave example.
+        $ localhost> ./launch.sh
 
-    $clusterData = {
-    	"east" => {
-    		"topology" => "master-slave",
-    		"master" => "db1",
-    		"slaves" => "db2,db3",
-    	},
-    }
+    Once you are finished with the instances
 
-    class { "continuent_vagrant" : clusterData => $clusterData, installPuppetLabsMySQL => true}
+        $ localhost> vagrant destroy -f
 
-    class { 'tungsten' :
-    	installSSHKeys => true,
-    	replicatorRepo => stable,
-    	installReplicatorSoftware => true,
-    	clusterData => $clusterData,
-    }
+
 
 # Using the vagrant-cachier plugin
 

--- a/examples/Vagrantfile.2.ec2
+++ b/examples/Vagrantfile.2.ec2
@@ -91,6 +91,7 @@ Vagrant.configure("2") do |vcfg|
 						"aws_secret_access_key" => SECRET_ACCESS_KEY,
 						"ec2_tag_group_key" => "VagrantGroup",
 						"ec2_tag_group_value" => GROUP,
+						"platform"=>"ec2'
 					}
 				end
 			end

--- a/examples/Vagrantfile.2.vbox
+++ b/examples/Vagrantfile.2.vbox
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |vcfg|
 				puppet.module_path = "modules"
 				puppet.facter = {
 					"vagrant" => "1",
-					"fqdn" => "db#{i}"
+					"fqdn" => "db#{i}",
+						"platform"=>"virtualbox'
 				}
 
 				# Set the temp directory name for an error in Vagrant 1.4.1

--- a/examples/Vagrantfile.3.ec2
+++ b/examples/Vagrantfile.3.ec2
@@ -91,6 +91,7 @@ Vagrant.configure("2") do |vcfg|
 						"aws_secret_access_key" => SECRET_ACCESS_KEY,
 						"ec2_tag_group_key" => "VagrantGroup",
 						"ec2_tag_group_value" => GROUP,
+						"platform"=>"ec2'
 					}
 				end
 			end

--- a/examples/Vagrantfile.3.openstack
+++ b/examples/Vagrantfile.3.openstack
@@ -16,7 +16,7 @@ Vagrant.configure("2") do |vcfg|
 			config.vm.box = "dummyOS"
 			config.ssh.pty = true
 			config.ssh.private_key_path = SSH_PRIVATE_KEY
-		
+
 			config.vm.provider :openstack do |os|
 				os.username     = API_USER
                 os.api_key      = API_PASSWORD
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |vcfg|
                 os.keypair_name = SSH_KEYPAIR
                 os.ssh_username = VM_USER
                 os.floating_ip  = "85.10.221.14#{i+5}"
-				
+
 				# Disable the requiretty setting and install puppet
 
                 os.user_data = "#!/bin/bash
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |vcfg|
 					puppet.facter = {
 						"vagrant" => "1",
 						"fqdn" => name.to_s(),
+						"platform"=>"openstack'
 					}
 				end
 			end

--- a/examples/Vagrantfile.3.vbox
+++ b/examples/Vagrantfile.3.vbox
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |vcfg|
 				puppet.module_path = "modules"
 				puppet.facter = {
 					"vagrant" => "1",
-					"fqdn" => "db#{i}"
+					"fqdn" => "db#{i}",
+					"platform"=>"virtualbox'
 				}
 
 				# Set the temp directory name for an error in Vagrant 1.4.1

--- a/examples/Vagrantfile.3.vcenter
+++ b/examples/Vagrantfile.3.vcenter
@@ -1,6 +1,6 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vcenter'
 VCENTER_SERVER=<vcenter host>
-VCENTER_USER= 
+VCENTER_USER=
 VCENTER_PASS=
 VCENTER_FOLDER=
 VCENTER_DATACENTER=
@@ -69,7 +69,7 @@ Vagrant.configure('2') do |config|
 					puppet.options = ""
 					puppet.module_path = "modules"
 					puppet.facter = {
-						"vagrant" => "1"
+						"vagrant" => "1","platform"=>'vcenter'
 			}
 				# Set the temp directory name for an error in Vagrant 1.4.1
 				begin

--- a/examples/Vagrantfile.3.vcenter
+++ b/examples/Vagrantfile.3.vcenter
@@ -25,6 +25,7 @@ Vagrant.configure('2') do |config|
 	# Go through nodes and configure each of them.
 	nodes.each do |node|
 
+    config.puppet_install.puppet_version = "3.7.3"
 		config.vm.provider :vcenter do |vcenter|
 			vcenter.hostname = VCENTER_SERVER
 			vcenter.username = VCENTER_USER

--- a/examples/Vagrantfile.3.vcenter
+++ b/examples/Vagrantfile.3.vcenter
@@ -1,0 +1,74 @@
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vcenter'
+
+nodes = []
+
+[*1..3].each do |n|
+	nodes << { hostname: "db#{n}",
+						box: 'gosddc/centos65-x64',
+						ip: "192.168.0.18#{n}",
+						mem: 2048,
+						cpu: 2 }
+end
+
+
+
+Vagrant.configure('2') do |config|
+
+	# Go through nodes and configure each of them.
+	nodes.each do |node|
+
+		config.vm.provider :vcenter do |vcenter|
+			vcenter.hostname = '192.168.0.150'
+			vcenter.username = 'root'
+			vcenter.password = 'vmware'
+			vcenter.folder_name = 'Vagrant'
+			vcenter.datacenter_name = 'TLO'
+			vcenter.computer_name = 'Cluster1'
+			vcenter.datastore_name = 'NAS'
+			vcenter.network_name = 'VM Network'
+			vcenter.linked_clones = true
+		end
+
+		config.vm.define node[:hostname] do |node_config|
+			node_config.vm.box = node[:box]
+			node_config.vm.hostname = node[:hostname]
+
+			# Let's configure the network for the VM, only the ip changes and is
+			# coming from the nodes array
+			node_config.vm.network :public_network,
+														ip: node[:ip],
+														netmask: '255.255.0.0',
+														gateway: '192.168.0.1',
+														dns_server_list: ['8.8.4.4', '8.8.8.8'],
+														dns_suffix_list: ['narmitag.com']
+
+			# Let's override some provider settings for specific VMs
+			node_config.vm.provider :vcenter do |override|
+				# Override number of cpu and memory based on what's in the nodes array
+				override.num_cpu = node[:cpu]
+				override.memory = node[:mem]
+				case node[:hostname]
+				# Override the folder name based on the hostname of the VM
+				when /centos/
+					override.folder_name = 'Vagrant/centos'
+				when /precise/
+					override.folder_name = 'Vagrant/ubuntu/precise'
+					override.enable_vm_customization = false
+				end
+			end
+			node_config.nfs.functional = false
+				config.vm.provision "puppet" do |puppet|
+					puppet.options = ""
+					puppet.module_path = "modules"
+					puppet.facter = {
+						"vagrant" => "1",
+						"fqdn" => "db#{i}"
+			}
+				# Set the temp directory name for an error in Vagrant 1.4.1
+				begin
+					puppet.temp_dir = "/tmp/vagrant-puppet"
+				rescue
+				end
+		end
+	end
+end

--- a/examples/Vagrantfile.6.ec2
+++ b/examples/Vagrantfile.6.ec2
@@ -91,6 +91,7 @@ Vagrant.configure("2") do |vcfg|
 						"aws_secret_access_key" => SECRET_ACCESS_KEY,
 						"ec2_tag_group_key" => "VagrantGroup",
 						"ec2_tag_group_value" => GROUP,
+							"platform"=>"ec2'
 					}
 				end
 			end

--- a/examples/Vagrantfile.6.ec2.multiaz
+++ b/examples/Vagrantfile.6.ec2.multiaz
@@ -109,6 +109,7 @@ Vagrant.configure("2") do |vcfg|
 						"aws_secret_access_key" => SECRET_ACCESS_KEY,
 						"ec2_tag_group_key" => "VagrantGroup",
 						"ec2_tag_group_value" => GROUP,
+							"platform"=>"ec2'
 					}
 				end
 			end

--- a/examples/Vagrantfile.6.vbox
+++ b/examples/Vagrantfile.6.vbox
@@ -18,7 +18,8 @@ Vagrant.configure("2") do |vcfg|
 				puppet.module_path = "modules"
 				puppet.facter = {
 					"vagrant" => "1",
-					"fqdn" => "db#{i}"
+					"fqdn" => "db#{i}",
+					"platform"=>"virtualbox'
 				}
 
 				# Set the temp directory name for an error in Vagrant 1.4.1

--- a/examples/Vagrantfile.6.vcenter
+++ b/examples/Vagrantfile.6.vcenter
@@ -1,6 +1,6 @@
 ENV['VAGRANT_DEFAULT_PROVIDER'] = 'vcenter'
 VCENTER_SERVER=<vcenter host>
-VCENTER_USER= 
+VCENTER_USER=
 VCENTER_PASS=
 VCENTER_FOLDER=
 VCENTER_DATACENTER=
@@ -10,7 +10,7 @@ VCENTER_NETWORK=
 
 nodes = []
 
-[*1..3].each do |n|
+[*1..6].each do |n|
 	nodes << { hostname: "db#{n}",
 						box: 'gosddc/centos65-x64',
 						ip: "192.168.0.18#{n}",

--- a/examples/Vagrantfile.6.vcenter
+++ b/examples/Vagrantfile.6.vcenter
@@ -69,7 +69,7 @@ Vagrant.configure('2') do |config|
 					puppet.options = ""
 					puppet.module_path = "modules"
 					puppet.facter = {
-						"vagrant" => "1"
+						"vagrant" => "1","platform"=>'vcenter'
 			}
 				# Set the temp directory name for an error in Vagrant 1.4.1
 				begin

--- a/examples/Vagrantfile.6.vcenter
+++ b/examples/Vagrantfile.6.vcenter
@@ -25,6 +25,7 @@ Vagrant.configure('2') do |config|
 	# Go through nodes and configure each of them.
 	nodes.each do |node|
 
+		config.puppet_install.puppet_version = "3.7.3"
 		config.vm.provider :vcenter do |vcenter|
 			vcenter.hostname = VCENTER_SERVER
 			vcenter.username = VCENTER_USER

--- a/launch.sh
+++ b/launch.sh
@@ -12,7 +12,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 # License for the specific language governing permissions and limitations
 # under the License.
- 
+
 MAX_PROCS=4
 PROVIDER='virtualbox'
 CHECKSTRING='running ('
@@ -45,7 +45,7 @@ parallel_provision() {
     done | xargs -P $MAX_PROCS -I"BOXNAME" \
         sh -c 'vagrant provision BOXNAME >BOXNAME.out.log 2>&1 || echo "Error Occurred: BOXNAME"'
 }
- 
+
 ## -- main -- ##
 
 
@@ -54,6 +54,7 @@ vagrant destroy -f $*
 
 IS_AWS=`grep vm.box Vagrantfile | grep dummy | wc -l`
 IS_OS=`grep vm.box Vagrantfile | grep dummyOS | wc -l`
+IS_VCENTER=`grep vp.provider Vagrantfile | grep vcenter | wc -l`
 
 if [ $IS_AWS -eq 1 ]
 then
@@ -67,6 +68,12 @@ then
     CHECKSTRING='active ('
 fi
 
+if [ $IS_VCENTER -eq 1 ]
+then
+    PROVIDER='vcenter'
+    CHECKSTRING='active ('
+fi
+
 vagrant up --no-provision --provider=$PROVIDER $*
 sleep 5
 
@@ -77,6 +84,12 @@ else
 fi
 
 if [ $IS_OS -eq 1 ]
+then
+    set_hostfile
+
+fi
+
+if [ $IS_VCENTER  -eq 1 ]
 then
     set_hostfile
 

--- a/launch.sh
+++ b/launch.sh
@@ -24,6 +24,7 @@ cd `dirname $0`
 set_hostfile() {
 
    rm -f hostfile.txt
+   echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4' > hostfile.txt
    for box in `echo $HOSTS| tr "\n" " "`
    do
       echo "Getting IP Details for $box" 1>&2
@@ -32,7 +33,7 @@ set_hostfile() {
     done
    for box in `echo $HOSTS| tr "\n" " "`
    do
-      vagrant ssh $box -c "sudo echo \"`cat hostfile.txt`\" >> /etc/hosts"
+      vagrant ssh $box -c "sudo echo \"`cat hostfile.txt`\"| sudo tee  /etc/hosts"
     done
 }
 
@@ -54,7 +55,7 @@ vagrant destroy -f $*
 
 IS_AWS=`grep vm.box Vagrantfile | grep dummy | wc -l`
 IS_OS=`grep vm.box Vagrantfile | grep dummyOS | wc -l`
-IS_VCENTER=`grep vp.provider Vagrantfile | grep vcenter | wc -l`
+IS_VCENTER=`grep vm.provider Vagrantfile |head -n1| grep vcenter | wc -l`
 
 if [ $IS_AWS -eq 1 ]
 then
@@ -71,7 +72,7 @@ fi
 if [ $IS_VCENTER -eq 1 ]
 then
     PROVIDER='vcenter'
-    CHECKSTRING='active ('
+    CHECKSTRING='running ('
 fi
 
 vagrant up --no-provision --provider=$PROVIDER $*

--- a/modules/continuent_vagrant/manifests/hosts.pp
+++ b/modules/continuent_vagrant/manifests/hosts.pp
@@ -1,13 +1,13 @@
 # == Class: continuent_vagrant::hosts See README.md for documentation.
 #
 # Copyright (C) 2014 Continuent, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License.  You may obtain
 # a copy of the License at
-# 
+#
 #         http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -16,14 +16,16 @@
 
 class continuent_vagrant::hosts {
 	if $ec2_instance_id == "" {
-		host { "db1": ip => "192.168.11.101", }
-		host { "db2": ip => "192.168.11.102", }
-		host { "db3": ip => "192.168.11.103", }
-		host { "db4": ip => "192.168.11.104", }
-		host { "db5": ip => "192.168.11.105", }
-		host { "db6": ip => "192.168.11.106", }
-		host { "db7": ip => "192.168.11.107", }
-		host { "db8": ip => "192.168.11.108", }
+	  if $platform == 'virtualbox'  or $platform == '' {
+			host { "db1": ip => "192.168.11.101", }
+			host { "db2": ip => "192.168.11.102", }
+			host { "db3": ip => "192.168.11.103", }
+			host { "db4": ip => "192.168.11.104", }
+			host { "db5": ip => "192.168.11.105", }
+			host { "db6": ip => "192.168.11.106", }
+			host { "db7": ip => "192.168.11.107", }
+			host { "db8": ip => "192.168.11.108", }
+		}
 	} else {
     #Openstack hosts have the ec2 facts loaded but
     #they have AZ of nova


### PR DESCRIPTION
the new facter value on the puppet apply it optional. existing Vagrantfiles without it will continue to work for both EC2 and virtualbox